### PR TITLE
Fix Three.js module import error

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -192,6 +192,15 @@
       {% endif %}
     </script>
 
+    <!-- Import map for Three.js modules -->
+    <script type="importmap">
+    {
+      "imports": {
+        "three": "/static/js/three.module.js"
+      }
+    }
+    </script>
+
     <!-- Load Go WASM runtime -->
     <script src="/static/js/wasm_exec.js"></script>
     <script>


### PR DESCRIPTION
Add import map to resolve 'three' module specifier to /static/js/three.module.js. This fixes the error: "The specifier 'three' was a bare specifier, but was not remapped to anything" when GLTFLoader.js tries to import from 'three'.