### PR TITLE
Fix WebGL viewport drawing warning

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,11 @@
     <style>
         body, html { margin: 0; padding: 0; height: 100%; overflow: hidden; }
         #canvas-container { width: 100%; height: 100%; display: block; }
+        #canvas-container canvas {
+            display: block;
+            width: 100%;
+            height: 100%;
+        }
         #town-name-display {
             position: absolute;
             top: 10px;


### PR DESCRIPTION
Added explicit CSS styling for the canvas element inside #canvas-container to ensure the canvas display size matches the WebGL drawing buffer size. This resolves the "Drawing to a destination rect smaller than the viewport rect" warning by ensuring the canvas element properly fills its container at 100% width and height.

The mismatch occurred because while the renderer was set to window dimensions, the canvas element itself had no explicit sizing and relied on browser defaults.