### PR TITLE
Fix bottom menu selection and scrolling

### DIFF
--- a/static/css/mobile.css
+++ b/static/css/mobile.css
@@ -85,9 +85,16 @@
 
   /* Drag zone for bottom sheet gestures */
   .toolbar-drag-zone {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: var(--bottom-sheet-peek);
+    z-index: 1;
     touch-action: pan-y; /* Allow dragging gestures */
     -webkit-user-select: none;
     user-select: none;
+    cursor: grab;
   }
 
   .toolbar-drag-zone:active {

--- a/static/css/mobile.css
+++ b/static/css/mobile.css
@@ -80,6 +80,18 @@
     border-radius: 2.5px;
     opacity: 0.5;
     pointer-events: none;
+    z-index: 0;
+  }
+
+  /* Drag zone for bottom sheet gestures */
+  .toolbar-drag-zone {
+    touch-action: pan-y; /* Allow dragging gestures */
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  .toolbar-drag-zone:active {
+    cursor: grabbing !important;
   }
 
   #toolbar .card-body {
@@ -146,7 +158,7 @@
     font-size: 16px;
     cursor: pointer;
     -webkit-tap-highlight-color: rgba(0, 123, 255, 0.3);
-    touch-action: manipulation; /* Prevent double-tap zoom, allow taps */
+    /* touch-action inherited from parent #model-container (pan-y) */
   }
 
   .model-item:active {

--- a/static/js/mobile/mobile-ui.js
+++ b/static/js/mobile/mobile-ui.js
@@ -117,25 +117,22 @@ class MobileUI {
 
     if (!cardBody || !cardTitle) return;
 
-    // Touch start - begin drag (only on title area, not model container)
+    // Create a draggable header zone (includes drag handle area at top of toolbar)
+    const dragHandleZone = document.createElement('div');
+    dragHandleZone.className = 'toolbar-drag-zone';
+    dragHandleZone.style.cssText = `
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 60px;
+      z-index: 1;
+      cursor: grab;
+    `;
+    this.toolbar.insertBefore(dragHandleZone, cardBody);
+
+    // Touch start - begin drag (only on drag handle zone and title)
     this.boundHandlers.touchStart = (e) => {
-      // Don't drag if touching the scrollable model container
-      if (modelContainer && modelContainer.contains(e.target)) {
-        this.isDragging = false;
-        return;
-      }
-
-      // Don't drag if touching mode buttons or bottom section controls
-      const target = e.target;
-      if (target.closest('.mode-buttons') ||
-          target.closest('.toolbar-bottom-section') ||
-          target.closest('button') ||
-          target.closest('input') ||
-          target.closest('select')) {
-        this.isDragging = false;
-        return;
-      }
-
       const touch = e.touches[0];
       this.touchStartY = touch.clientY;
       this.isDragging = true;
@@ -185,9 +182,19 @@ class MobileUI {
       this.isDragging = false;
     };
 
-    this.toolbar.addEventListener('touchstart', this.boundHandlers.touchStart, { passive: true });
-    this.toolbar.addEventListener('touchmove', this.boundHandlers.touchMove, { passive: true });
-    this.toolbar.addEventListener('touchend', this.boundHandlers.touchEnd, { passive: true });
+    // Attach touch listeners ONLY to the drag handle zone and title
+    // This prevents interference with model container scrolling and clicking
+    dragHandleZone.addEventListener('touchstart', this.boundHandlers.touchStart, { passive: true });
+    dragHandleZone.addEventListener('touchmove', this.boundHandlers.touchMove, { passive: true });
+    dragHandleZone.addEventListener('touchend', this.boundHandlers.touchEnd, { passive: true });
+
+    cardTitle.addEventListener('touchstart', this.boundHandlers.touchStart, { passive: true });
+    cardTitle.addEventListener('touchmove', this.boundHandlers.touchMove, { passive: true });
+    cardTitle.addEventListener('touchend', this.boundHandlers.touchEnd, { passive: true });
+
+    // Store references for cleanup
+    this.dragHandleZone = dragHandleZone;
+    this.cardTitle = cardTitle;
   }
 
   /**
@@ -315,16 +322,34 @@ class MobileUI {
     }
 
     // Remove toolbar gesture listeners
-    if (this.toolbar) {
+    if (this.dragHandleZone) {
       if (this.boundHandlers.touchStart) {
-        this.toolbar.removeEventListener('touchstart', this.boundHandlers.touchStart);
+        this.dragHandleZone.removeEventListener('touchstart', this.boundHandlers.touchStart);
       }
       if (this.boundHandlers.touchMove) {
-        this.toolbar.removeEventListener('touchmove', this.boundHandlers.touchMove);
+        this.dragHandleZone.removeEventListener('touchmove', this.boundHandlers.touchMove);
       }
       if (this.boundHandlers.touchEnd) {
-        this.toolbar.removeEventListener('touchend', this.boundHandlers.touchEnd);
+        this.dragHandleZone.removeEventListener('touchend', this.boundHandlers.touchEnd);
       }
+      this.dragHandleZone.remove();
+      this.dragHandleZone = null;
+    }
+
+    if (this.cardTitle) {
+      if (this.boundHandlers.touchStart) {
+        this.cardTitle.removeEventListener('touchstart', this.boundHandlers.touchStart);
+      }
+      if (this.boundHandlers.touchMove) {
+        this.cardTitle.removeEventListener('touchmove', this.boundHandlers.touchMove);
+      }
+      if (this.boundHandlers.touchEnd) {
+        this.cardTitle.removeEventListener('touchend', this.boundHandlers.touchEnd);
+      }
+      this.cardTitle = null;
+    }
+
+    if (this.toolbar) {
       this.toolbar.classList.remove('open');
       this.toolbar.style.transform = '';
     }

--- a/static/js/mobile/mobile-ui.js
+++ b/static/js/mobile/mobile-ui.js
@@ -120,18 +120,9 @@ class MobileUI {
     // Create a draggable header zone (includes drag handle area at top of toolbar)
     const dragHandleZone = document.createElement('div');
     dragHandleZone.className = 'toolbar-drag-zone';
-    dragHandleZone.style.cssText = `
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      height: 60px;
-      z-index: 1;
-      cursor: grab;
-    `;
     this.toolbar.insertBefore(dragHandleZone, cardBody);
 
-    // Touch start - begin drag (only on drag handle zone and title)
+    // Touch start - begin drag
     this.boundHandlers.touchStart = (e) => {
       const touch = e.touches[0];
       this.touchStartY = touch.clientY;
@@ -182,19 +173,14 @@ class MobileUI {
       this.isDragging = false;
     };
 
-    // Attach touch listeners ONLY to the drag handle zone and title
+    // Attach touch listeners ONLY to the drag handle zone
     // This prevents interference with model container scrolling and clicking
     dragHandleZone.addEventListener('touchstart', this.boundHandlers.touchStart, { passive: true });
     dragHandleZone.addEventListener('touchmove', this.boundHandlers.touchMove, { passive: true });
     dragHandleZone.addEventListener('touchend', this.boundHandlers.touchEnd, { passive: true });
 
-    cardTitle.addEventListener('touchstart', this.boundHandlers.touchStart, { passive: true });
-    cardTitle.addEventListener('touchmove', this.boundHandlers.touchMove, { passive: true });
-    cardTitle.addEventListener('touchend', this.boundHandlers.touchEnd, { passive: true });
-
-    // Store references for cleanup
+    // Store reference for cleanup
     this.dragHandleZone = dragHandleZone;
-    this.cardTitle = cardTitle;
   }
 
   /**
@@ -334,19 +320,6 @@ class MobileUI {
       }
       this.dragHandleZone.remove();
       this.dragHandleZone = null;
-    }
-
-    if (this.cardTitle) {
-      if (this.boundHandlers.touchStart) {
-        this.cardTitle.removeEventListener('touchstart', this.boundHandlers.touchStart);
-      }
-      if (this.boundHandlers.touchMove) {
-        this.cardTitle.removeEventListener('touchmove', this.boundHandlers.touchMove);
-      }
-      if (this.boundHandlers.touchEnd) {
-        this.cardTitle.removeEventListener('touchend', this.boundHandlers.touchEnd);
-      }
-      this.cardTitle = null;
     }
 
     if (this.toolbar) {


### PR DESCRIPTION
Fixed issue where users couldn't scroll or click on items in the mobile bottom sheet menu. The problem was touch event listeners attached to the entire toolbar were blocking interactions with child elements.

Changes:
- Created dedicated drag handle zone for bottom sheet gestures
- Moved touch event listeners from entire toolbar to only drag zone and title
- Removed conflicting touch-action CSS property from model items
- Added proper CSS styling for drag handle zone

This allows the model container to receive touch events normally while still preserving the drag-to-open/close functionality for the bottom sheet.

Fixes: Bottom menu interaction on mobile devices